### PR TITLE
Add & use generated bluelinks xrpc agent

### DIFF
--- a/src/actions/linksAction.ts
+++ b/src/actions/linksAction.ts
@@ -1,6 +1,5 @@
-import { getHandleFromDID, restoreSession } from "@/atproto";
+import { getBlueLinksAgent, getHandleFromDID, restoreSession } from "@/atproto";
 import { createAuthClient } from "@/auth/client";
-import { Agent } from "@atproto/api";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import * as Links from '@/lexicon/types/fyi/bluelinks/links';
@@ -32,8 +31,10 @@ export const linksAction = async (prevState: any, formData: FormData) => {
     }
 
     // make agent for user and save record
-    const agent = new Agent(session);
+    const agent = getBlueLinksAgent(session);
     await agent.com.atproto.repo.putRecord({
+        // code gen from @atproto/lex-cli doesn't include a .put() or .update() method on the fyi.bluelinks.links namespace,
+        // have to use com.atproto.repo.putRecord with the collection name and validate the record above
         repo: session.did,
         collection: 'fyi.bluelinks.links',
         rkey: 'self',

--- a/src/app/(web)/edit/page.tsx
+++ b/src/app/(web)/edit/page.tsx
@@ -1,8 +1,7 @@
 import { linksAction } from "@/actions/linksAction";
-import { restoreSession } from "@/atproto";
+import { getBlueLinksAgent, restoreSession } from "@/atproto";
 import { createAuthClient } from "@/auth/client";
 import LinksForm from "@/forms/LinksForm";
-import { Agent } from "@atproto/api";
 import { Metadata } from "next";
 import { cookies } from "next/headers"
 import { redirect } from "next/navigation";
@@ -23,22 +22,17 @@ const EditPage = async () => {
         return redirect('/login');
     } else {
         // get link data from user
-        const agent = new Agent(session);
+        const agent = getBlueLinksAgent(session);
 
         let linksRecord: Links.Record;
         try {
-            const response = await agent.com.atproto.repo.getRecord({
+            const data = await agent.fyi.bluelinks.links.get({
                 repo: session.did,
-                collection: 'fyi.bluelinks.links',
                 rkey: 'self'
             });
 
-            if (!Links.isRecord(response.data.value) || !Links.validateRecord(response.data.value).success) {
-                throw new Error('Invalid record retrieved');
-            }
-
-            linksRecord = response.data.value;
-        } catch (e) {
+            linksRecord = data.value;
+        } catch(e) {
             console.log(e);
             linksRecord = {
                 links: []

--- a/src/app/(web)/u/[handle]/page.tsx
+++ b/src/app/(web)/u/[handle]/page.tsx
@@ -1,5 +1,5 @@
-import { Agent, AppBskyActorProfile } from "@atproto/api";
-import { getDIDDoc, restoreSession } from "../../../../atproto";
+import { AppBskyActorProfile } from "@atproto/api";
+import { getBlueLinksAgent, getDIDDoc, restoreSession } from "../../../../atproto";
 import UserImage from "./UserImage";
 import { notFound } from "next/navigation";
 import { Metadata } from "next";
@@ -31,7 +31,7 @@ const User = async ({ params }: Props) => {
         return notFound();
     }
 
-    const agent = new Agent(didDoc.serviceEndpoint);
+    const agent = getBlueLinksAgent(didDoc.serviceEndpoint);
 
     const profileRecord = await agent.com.atproto.repo.getRecord({
         repo: didDoc.id,
@@ -42,18 +42,13 @@ const User = async ({ params }: Props) => {
 
     let linksRecord: Links.Record;
     try {
-        const response = await agent.com.atproto.repo.getRecord({
+        const data = await agent.fyi.bluelinks.links.get({
             repo: didDoc.id,
-            collection: 'fyi.bluelinks.links',
             rkey: 'self'
         });
 
-        if (!Links.isRecord(response.data.value) || !Links.validateRecord(response.data.value).success) {
-            throw new Error('Invalid record retrieved');
-        }
-
-        linksRecord = response.data.value;
-    } catch (e) {
+        linksRecord = data.value;
+    } catch(e) {
         console.log(e);
         linksRecord = {
             links: []

--- a/src/app/delete/route.ts
+++ b/src/app/delete/route.ts
@@ -1,10 +1,10 @@
-import { getHandleFromDID, restoreSession } from "@/atproto";
+import { getBlueLinksAgent, getHandleFromDID, restoreSession } from "@/atproto";
 import { createAuthClient } from "@/auth/client";
-import { Agent } from "@atproto/api";
 import { cookies } from "next/headers"
 import { redirect } from "next/navigation";
 
-const collections = ['fyi.bluelinks.links', 'info.timjefferson.dev.blue-links.links'];
+// Collection names the app has used previously
+const possibleCollections = ['info.timjefferson.dev.blue-links.links'];
 
 // For the current user, delete any records that this app has potentially created
 export const GET = async () => {
@@ -22,14 +22,20 @@ export const GET = async () => {
             redirect('/login');
         }
 
-        const agent = new Agent(session);
+        const agent = getBlueLinksAgent(session);
         const handle = await getHandleFromDID(session.did);
 
-        // delete records
-        for (let i = 0; i < collections.length; i++) {
+        // delete fyi.bluelinks.* namespace collections / records
+        await agent.fyi.bluelinks.links.delete({
+            repo: session.did,
+            rkey: 'self'
+        });
+
+        // delete extra records not in fyi.bluelinks.* namespace that the app possibly has made
+        for (let i = 0; i < possibleCollections.length; i++) {
             await agent.com.atproto.repo.deleteRecord({
                 repo: session.did,
-                collection: collections[i],
+                collection: possibleCollections[i],
                 rkey: 'self'
             })
         }

--- a/src/atproto.ts
+++ b/src/atproto.ts
@@ -1,6 +1,8 @@
-import { AtUri } from "@atproto/api";
+import { Agent, AtUri } from "@atproto/api";
 import { DidDocument, DidResolver, HandleResolver } from "@atproto/identity"
 import { NodeOAuthClient } from "@atproto/oauth-client-node";
+import { AtpBaseClient, FyiNS } from "./lexicon";
+import { SessionManager } from "@atproto/api/dist/session-manager";
 
 interface DidDocumentWithServiceEndpoint extends DidDocument {
     serviceEndpoint: string
@@ -68,4 +70,12 @@ export const getHandleFromDID = async (did: string): Promise<string | null> => {
         const uri = new AtUri(knownAs);
         return uri.host;
     }
+}
+
+type IBlueLinksAgent = Agent & AtpBaseClient;
+export const getBlueLinksAgent = (options: string | URL | SessionManager) => {
+    const agent = new Agent(options) as IBlueLinksAgent;
+    agent.fyi = new FyiNS(agent);
+
+    return agent;
 }


### PR DESCRIPTION
reran the lex-cli and this time used the command `gen-api` to output an XRPC client with `fyi.bluelinks.*` namespace helpers.

this way when fetching a user's links we can do `agent.fyi.bluelinks.links.get()` instead of `agent.com.atproto.repo.getRecord({ ... })`

had to leave the `com.atproto.repo.putRecord()` call as the code gen doesn't include a `fyi.bluelinks.links.put()` method